### PR TITLE
Isolating build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+run:
+  virtualenv env && source env/bin/activate && \
+  pip install mkdocs beautifulsoup4 && \
+  sh build.sh $(version)
+  -rm -rf env/

--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@ drf-dash
 
 Build Django REST framework docset for Dash (http://kapeli.com/dash/)
 
+Dependencies
+------------
+
+- [virtualenv](http://virtualenv.readthedocs.org/en/latest/installation.html)
+
 Instructions
 ------------
 
 ```
-$ sh build.sh 3.2.4
+$ make run 3.2.4
 $ ls build
 ```


### PR DESCRIPTION
Hi! I notice that you're expecting that the user already has a **mkdocs** and **beautifulsoup4** installed. As i'm not really needing this two on my global path i decide to isolate the build dependencies on the Makefile and resuming it to: **virtualenv** :)